### PR TITLE
Added Apache WordPress XMLRPC posts filter

### DIFF
--- a/etc/fail2ban/filter.d/apache-wordpress-xmlrpc.conf
+++ b/etc/fail2ban/filter.d/apache-wordpress-xmlrpc.conf
@@ -1,0 +1,16 @@
+# Fail2Ban filter for WordPress XMLRPC for Apache
+#
+# Author: Mark van Driel
+#
+
+[Definition]
+
+# Option:  failregex
+# Notes.:  regex to match XMLRPC posts on WordPress for Apache
+# Values:  TEXT
+failregex = <HOST>.*] "POST /xmlrpc\.php
+
+# Option:  ignoreregex
+# Notes.:  regex to ignore. If this regex matches, the line is ignored.
+# Values:  TEXT
+ignoreregex =


### PR DESCRIPTION
This filter could be useful to block brute force amplification attacks against WordPress XMLRPC. see: https://blog.sucuri.net/2015/10/brute-force-amplification-attacks-against-wordpress-xmlrpc.html
